### PR TITLE
swap gitleaks for Yelp version in precommit, add gitleaks to CICD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,5 +43,12 @@
 
                 - name: Cleanup residue file
                   run: make clean
+
+                - name: setup gitleaks
+                  run: make setup-gitleaks
+                
+                - name: run gitleaks
+                  run: make run-gitleaks
+
     
     

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,13 @@ repos:
       - id: check-yaml
       - id: debug-statements
       - id: check-merge-conflict
+      - id: detect-private-key # detects the presence of private keys.
+      - id: check-added-large-files # check for files above certain size (as likely to be data files)
+        args: ['--maxkb=500']
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.5.0
+    hooks:
+      - id: detect-secrets
   - repo: local
     hooks:
       - id: forbid-new-init
@@ -19,14 +26,6 @@ repos:
         entry: python
         language: fail
         files: ^src/__init__.py$
-      - id: setup-gitleaks
-        name: Grab the gitleaks Docker image
-        entry: make setup-gitleaks
-        language: system
-      - id: run-gitleaks
-        name: Check commits for secrets, using gitleaks Docker image
-        entry: make run-gitleaks
-        language: system
       - id: vulnerability-linting-checks
         name: Run vulnerability detection checks (bandit)
         entry: make check-python-security


### PR DESCRIPTION
# 📌 Remove Gitleaks as (local) dependency

## ✨ Summary

ONS Windows devices can't use docker, which was a requirement to run gitleaks as a pre-commit hook.
This PR replaces gitleaks secret scanning with a similar, less powerful secret scanner which doesn't require docker, and adds the gitleaks secret scanning to the CICD pipeline to scan merge requests to `main` (also as a test ground for setting up `pre-recieve` hooks as Actions).

## 📜 Changes Introduced

- [x] chore: remove `gitleaks` from pre-commits, add in new secret scanner to pre-commits, add `gitleaks` to CICD

## ✅ Checklist

- [ ] Code is formatted using **Black**
- [ ] Imports are sorted using **isort**
- [ ] Code passes linting with **Ruff**, **Pylint**, and **Mypy**
- [ ] Security checks pass using **Bandit**
- [ ] API and Unit tests are written and pass using **pytest**
- [ ] Terraform files (if applicable) follow best practices and have been validated (`terraform fmt` & `terraform validate`)
- [ ] DocStrings follow Google-style and are added as per Pylint recommendations
- [ ] Documentation has been updated if needed

## 🔍 How to Test

CICD: will be tested on creating this PR

pre-commit hooks: check out this branch, make a change and commit it; verify the new checks run.
