### PR TITLE
update precommit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,6 +29,6 @@ repos:
         language: system
       - id: vulnerability-linting-checks
         name: Run vulnerability detection checks (bandit)
-        entry: make check-python-security
+        entry: uv tool run bandit -r src
         language: system
         


### PR DESCRIPTION
# 📌 Make pre-commit setup windows compatible

## ✨ Summary

pre-commit hooks had been referencing Makefile orchestrated actions, but `make` is not readily available on Windows ONS devices. This PR removes that requirement.

## 📜 Changes Introduced

<!-- List key changes made in this PR. Consider bullet points for readability. -->

- [ ] chore: refactor pre-commit hooks to remove make dependency

## ✅ Checklist

> **Please confirm you've completed these checks before requesting a review.**

- [ ] Code is formatted using **Black**
- [ ] Imports are sorted using **isort**
- [ ] Code passes linting with **Ruff**, **Pylint**, and **Mypy**
- [ ] Security checks pass using **Bandit**
- [ ] API and Unit tests are written and pass using **pytest**
- [ ] Terraform files (if applicable) follow best practices and have been validated (`terraform fmt` & `terraform validate`)
- [ ] DocStrings follow Google-style and are added as per Pylint recommendations
- [ ] Documentation has been updated if needed

## 🔍 How to Test

run pre-commit install; confirm it completes successfully
